### PR TITLE
Add clamscan predefined script for virus scanning

### DIFF
--- a/src/main/java/tr/org/lider/services/ScriptService.java
+++ b/src/main/java/tr/org/lider/services/ScriptService.java
@@ -34,6 +34,15 @@ public class ScriptService {
 			String contents = "#!/bin/bash\n" + 
 					"touch /tmp/test.txt";
 			scriptRepository.save(new ScriptTemplate(scriptType, label, contents, new Date(), null, false));
+			
+			scriptType = ScriptType.getType(1);
+			label = "Virüs Taraması Yap";
+			contents = "#!/bin/bash\n" + 
+				"sudo apt install clamav\n" +
+				"sudo freshclam\n" + 
+				"clamscan -r -i /home &";
+			scriptRepository.save(new ScriptTemplate(scriptType, label, contents, new Date(), null, false));
+			
 		}
 	}
 


### PR DESCRIPTION
As far as I know there is no default antivirus feature on liderahenk. I suggest you add this clamav script to the default scripts. That would be good for server admins to quickly run virus scan on ahenk machines.
Note: I am not very familiar with Java language, I am open to your improvements