### PR TITLE
fix: call configurationService.destroyConfigParams() only when login instead of on every request.

### DIFF
--- a/src/main/java/tr/org/lider/controllers/AuthController.java
+++ b/src/main/java/tr/org/lider/controllers/AuthController.java
@@ -47,6 +47,7 @@ import tr.org.lider.security.JwtResponse;
 import tr.org.lider.security.LoginParams;
 import tr.org.lider.security.User;
 import tr.org.lider.services.OperationLogService;
+import tr.org.lider.services.ConfigurationService;
 
 @CrossOrigin(origins = "*", maxAge = 3600)
 @RestController
@@ -70,6 +71,9 @@ public class AuthController {
 
 	@Autowired
 	private JwtProvider jwtProvider;
+
+	@Autowired
+	private ConfigurationService configurationService;
 
 	@Value("${jwt.secret}")
 	private String jwtSecret;
@@ -98,6 +102,7 @@ public class AuthController {
 			Cache<String, String> cache = cacheManager.getCache("userCache");
 			cache.put(jwt, tokenData);
 			operationLogService.saveOperationLog(OperationType.LOGIN,"User logged in",null);
+			configurationService.destroyConfigParams();
 			return ResponseEntity.ok(new JwtResponse(jwt, userPrincipal.getName(), userPrincipal.getSurname()));
 		} catch (BadCredentialsException e) {
 			logger.warn("Username: " + loginParams.getUsername() + " requested to login but username or password is wrong. Returned: " + HttpStatus.NOT_FOUND);

--- a/src/main/java/tr/org/lider/services/UserService.java
+++ b/src/main/java/tr/org/lider/services/UserService.java
@@ -42,7 +42,6 @@ public class UserService implements UserDetailsService {
 		User user = null;
 		LdapEntry ldapEntry = null;
 		try {
-			configurationService.destroyConfigParams();
 			String filter= "(&(objectClass=pardusAccount)(objectClass=pardusLider)(liderPrivilege=ROLE_USER)(uid=$1))".replace("$1", userName);
 			List<LdapEntry> ldapEntries  = ldapService.findSubEntries(filter,
 					new String[] { "*" }, SearchScope.SUBTREE);


### PR DESCRIPTION
The previous logic was based on destroying and rebuilding the configparams on every request, which created a race condition where if multiple concurrent requests sent the application will throw null exception and reset JWT tokens mainly because database and ldap weren't speed enough to catch-up, creating unnecessary overload

With this commit config refresh only during actual user login while maintaining stable configuration during request processing. This prevent JWT token resets and eliminates session crashes under high concurrent load.